### PR TITLE
Refactor scan method to return CloseableSequence.

### DIFF
--- a/src/commonMain/kotlin/com/github/lamba92/leveldb/LevelDBReader.kt
+++ b/src/commonMain/kotlin/com/github/lamba92/leveldb/LevelDBReader.kt
@@ -18,24 +18,82 @@ public interface LevelDBReader {
      * in memory the data read from disk, default is `true`.
      * @return The value associated with the specified key, or null if the key does not exist.
      */
-    public fun get(key: String, verifyChecksums: Boolean = false, fillCache: Boolean = true): String?
+    public fun get(
+        key: String,
+        verifyChecksums: Boolean = false,
+        fillCache: Boolean = true
+    ): String?
 
     /**
-     * Creates an [Iterable] to traverse all key-value pairs in the LevelDB database.
+     * Creates an [Iterable] to traverse all key-value pairs in the LevelDB database. The sequence will
+     * start from the specified key, or from the first key if no key is specified. LevelDB sorts keys
+     * in lexicographic order.
+     *
+     * **IMPORTANT**: The returned sequence must be closed after use to release any underlying resources.
      *
      * @param verifyChecksums Indicates whether checksums should be verified during iteration to ensure data integrity.
      * @param fillCache Indicates whether the cache should be populated during iteration, that is to cache in memory the data read from disk.
      * @param from The key from which to start the iteration, default is `null`.
-     * @return An iterator over key-value pairs, where each pair consists of a key and its associated value.
+     * @return A [CloseableSequence] over key-value pairs, where each pair consists of a key and its associated value.
      */
-    public fun <T> scan(
+    public fun scan(
         from: String? = null,
         verifyChecksums: Boolean = false,
         fillCache: Boolean = true,
-        action: (Sequence<Entry>) -> T
-    ): T
+    ): CloseableSequence<LazyEntry>
 
+    /**
+     * Represents a key-value pair in a LevelDB database. The key and value are both lazy-initialized
+     * and read from the database only when accessed for the first time.
+     *
+     * @property key The key of the pair.
+     * @property value The value of the pair.
+     */
+    @Serializable
+    public data class LazyEntry(val key: Lazy<String>, val value: Lazy<String>)
+
+    /**
+     * Represents a key-value pair in a LevelDB database. The key and value are both eagerly initialized
+     * and read from the database when the pair is created.
+     *
+     * @property key The key of the pair.
+     * @property value The value of the pair.
+     */
     @Serializable
     public data class Entry(val key: String, val value: String)
 
 }
+
+/**
+ * Retrieves the value associated with a given key in the LevelDB database.
+ * This is a convenience method that returns the value as a [LevelDBReader.Entry] object.
+ * This method can be invoked only if the sequence is not closed.
+ *
+ */
+public fun LevelDBReader.LazyEntry.resolve(): LevelDBReader.Entry =
+    LevelDBReader.Entry(key.value, value.value)
+
+/**
+ * Creates an [Iterable] to traverse all key-value pairs in the LevelDB database. The sequence will
+ * start from the specified key, or from the first key if no key is specified. LevelDB sorts keys
+ * in lexicographic order.
+ *
+ * The provided sequence inside the [action] lambda is lazily evaluated, and the underlying resources are
+ * automatically released after the lambda completes execution.
+ *
+ * **IMPORTANT**: Do not store the sequence outside the lambda, as it will be closed automatically after the lambda completes execution.
+ *
+ * See [LevelDBReader.scan] for more information.
+ *
+ * @param verifyChecksums Indicates whether checksums should be verified during iteration to ensure data integrity.
+ * @param fillCache Indicates whether the cache should be populated during iteration, that is to cache in memory the data read from disk.
+ * @param from The key from which to start the iteration, default is `null`.
+ * @param action The action to be performed on the sequence of key-value pairs.
+ * @return A [CloseableSequence] over key-value pairs, where each pair consists of a key and its associated value.
+ */
+public inline fun <T> LevelDB.scan(
+    from: String? = null,
+    verifyChecksums: Boolean = false,
+    fillCache: Boolean = true,
+    action: (Sequence<LevelDBReader.LazyEntry>) -> T
+): T = scan(from, verifyChecksums, fillCache).use { action(it) }

--- a/src/commonMain/kotlin/com/github/lamba92/leveldb/LevelDBUtils.kt
+++ b/src/commonMain/kotlin/com/github/lamba92/leveldb/LevelDBUtils.kt
@@ -43,3 +43,37 @@ public expect fun destroyDatabase(path: String, options: LevelDBOptions = LevelD
     message = "This API is broken and will crash at runtime"
 )
 internal annotation class BrokenNativeAPI(val reason: String = "")
+
+/**
+ * Represents a sequence of elements that can be closed to release any underlying resources.
+ *
+ * This interface extends the standard [Sequence] interface and adds the [close] method
+ * to allow for explicit resource management.
+ *
+ * @param <T> the type of elements produced by this sequence
+ */
+public interface CloseableSequence<T> : Sequence<T>, AutoCloseable {
+    /**
+     * Closes this sequence and releases any underlying resources.
+     *
+     * This method should be called when the sequence is no longer needed to prevent
+     * resource leaks.
+     */
+    override fun close()
+}
+
+/**
+ * Wraps a [Sequence] into a [CloseableSequence] with a custom close action.
+ *
+ * This function allows you to associate a specific action to be executed when the
+ * resulting [CloseableSequence] is closed.
+ *
+ * @param T the type of elements produced by the sequence
+ * @param onClose the action to be executed when the sequence is closed
+ * @return a [CloseableSequence] that wraps the original sequence and executes the
+ *         specified action on close
+ */
+public fun <T> Sequence<T>.asCloseable(onClose: () -> Unit): CloseableSequence<T> =
+    object : CloseableSequence<T>, Sequence<T> by this {
+        override fun close() = onClose()
+    }

--- a/src/jvmCommonMain/kotlin/com/github/lamba92/leveldb/jvm/JvmLevelDB.kt
+++ b/src/jvmCommonMain/kotlin/com/github/lamba92/leveldb/jvm/JvmLevelDB.kt
@@ -1,6 +1,7 @@
 package com.github.lamba92.leveldb.jvm
 
 import com.github.lamba92.leveldb.BrokenNativeAPI
+import com.github.lamba92.leveldb.CloseableSequence
 import com.github.lamba92.leveldb.LevelDB
 import com.github.lamba92.leveldb.LevelDBBatchOperation
 import com.github.lamba92.leveldb.LevelDBReader
@@ -108,12 +109,12 @@ public class JvmLevelDB internal constructor(
             }
         }
 
-    override fun <T> scan(
+    override fun scan(
         from: String?,
         verifyChecksums: Boolean,
         fillCache: Boolean,
-        action: (Sequence<LevelDBReader.Entry>) -> T
-    ): T = nativeDatabase.sequence(verifyChecksums, fillCache, action, from)
+    ): CloseableSequence<LevelDBReader.LazyEntry> =
+        nativeDatabase.asSequence(verifyChecksums, fillCache, from)
 
     @BrokenNativeAPI
     override fun <T> withSnapshot(action: LevelDBSnapshot.() -> T): T {

--- a/src/jvmCommonMain/kotlin/com/github/lamba92/leveldb/jvm/JvmLevelDBSnapshot.kt
+++ b/src/jvmCommonMain/kotlin/com/github/lamba92/leveldb/jvm/JvmLevelDBSnapshot.kt
@@ -1,5 +1,6 @@
 package com.github.lamba92.leveldb.jvm
 
+import com.github.lamba92.leveldb.CloseableSequence
 import com.github.lamba92.leveldb.LevelDBReader
 import com.github.lamba92.leveldb.LevelDBSnapshot
 import kotlinx.datetime.Clock
@@ -15,10 +16,11 @@ public class JvmLevelDBSnapshot internal constructor(
     override fun get(key: String, verifyChecksums: Boolean, fillCache: Boolean): String? =
         nativeDatabase.get(verifyChecksums, fillCache, key, nativeSnapshot)
 
-    override fun <T> scan(
+    override fun scan(
         from: String?,
         verifyChecksums: Boolean,
         fillCache: Boolean,
-        action: (Sequence<LevelDBReader.Entry>) -> T
-    ): T = nativeDatabase.sequence(verifyChecksums, fillCache, action, from, nativeSnapshot)
+    ): CloseableSequence<LevelDBReader.LazyEntry> =
+        nativeDatabase.asSequence(verifyChecksums, fillCache, from, nativeSnapshot)
+
 }

--- a/src/nativeMain/kotlin/com/github/lamba92/leveldb/native/NativeLevelDB.kt
+++ b/src/nativeMain/kotlin/com/github/lamba92/leveldb/native/NativeLevelDB.kt
@@ -6,6 +6,7 @@ package com.github.lamba92.leveldb.native
 import cnames.structs.leveldb_options_t
 import cnames.structs.leveldb_t
 import com.github.lamba92.leveldb.BrokenNativeAPI
+import com.github.lamba92.leveldb.CloseableSequence
 import com.github.lamba92.leveldb.LevelDB
 import com.github.lamba92.leveldb.LevelDBBatchOperation
 import com.github.lamba92.leveldb.LevelDBReader
@@ -121,12 +122,12 @@ public class NativeLevelDB internal constructor(
         }
     }
 
-    override fun <T> scan(
+    override fun scan(
         from: String?,
         verifyChecksums: Boolean,
         fillCache: Boolean,
-        action: (Sequence<LevelDBReader.Entry>) -> T
-    ): T = nativeDatabase.sequence(verifyChecksums, fillCache, action, from)
+    ): CloseableSequence<LevelDBReader.LazyEntry> =
+        nativeDatabase.asSequence(verifyChecksums, fillCache, from)
 
     override fun <T> withSnapshot(action: LevelDBSnapshot.() -> T): T {
         val nativeSnapshot = leveldb_create_snapshot(nativeDatabase)

--- a/src/nativeMain/kotlin/com/github/lamba92/leveldb/native/NativeLevelDBSnapshot.kt
+++ b/src/nativeMain/kotlin/com/github/lamba92/leveldb/native/NativeLevelDBSnapshot.kt
@@ -2,6 +2,7 @@ package com.github.lamba92.leveldb.native
 
 import cnames.structs.leveldb_snapshot_t
 import cnames.structs.leveldb_t
+import com.github.lamba92.leveldb.CloseableSequence
 import com.github.lamba92.leveldb.LevelDBReader
 import com.github.lamba92.leveldb.LevelDBSnapshot
 import kotlinx.cinterop.CPointer
@@ -19,10 +20,10 @@ public class NativeLevelDBSnapshot(
     override fun get(key: String, verifyChecksums: Boolean, fillCache: Boolean): String? =
         nativeDatabase.get(verifyChecksums, fillCache, key, nativeSnapshot)
 
-    override fun <T> scan(
+    override fun scan(
         from: String?,
         verifyChecksums: Boolean,
         fillCache: Boolean,
-        action: (Sequence<LevelDBReader.Entry>) -> T
-    ): T = nativeDatabase.sequence(verifyChecksums, fillCache, action, from, nativeSnapshot)
+    ): CloseableSequence<LevelDBReader.LazyEntry> =
+        nativeDatabase.asSequence(verifyChecksums, fillCache, from, nativeSnapshot)
 }


### PR DESCRIPTION
This change refactors the `scan` method to return a `CloseableSequence` instead of using a callback, allowing for lazy evaluation of database entries. This approach improves resource management by enabling users to explicitly close sequences, preventing resource leaks and ensuring better control over the database iteration process.