### PR TITLE
Simplify workflows by removing release matrix.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,9 +7,8 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu, windows, macos ]
-        release: [ true, false ]
     runs-on: ${{ matrix.os }}-latest
-    name: "[${{ matrix.release == true && 'RELEASE' || 'DEBUG' }}] Benchmark ${{ matrix.os }}"
+    name: Benchmarks on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -18,7 +17,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - run: chmod +x gradlew
-      - run: ./gradlew runBenchmark "-Pleveldb.release=${{ matrix.release }}"
+      - run: ./gradlew runBenchmark
         env:
           OPERATIONS_COUNT: 1000000
           TEST_REPETITIONS: 10

--- a/.github/workflows/jvm-tests.yml
+++ b/.github/workflows/jvm-tests.yml
@@ -5,11 +5,8 @@ on: [ push, pull_request ]
 jobs:
   android-tests:
     continue-on-error: true
-    strategy:
-      matrix:
-        release: [true, false]
     runs-on: ubuntu-latest
-    name: "[${{ matrix.release == true && 'RELEASE' || 'DEBUG' }}] Android"
+    name: Android tests
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -18,7 +15,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - run: chmod +x gradlew
-      - run: ./gradlew assembleDebug "-Pleveldb.release=${{ matrix.release }}"
+      - run: ./gradlew assembleDebug
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -36,7 +33,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: tests-results-android-${{ matrix.release == true && 'release' || 'debug' }}
+          name: tests-results-android
           path: build/reports
 
   jvm-tests:
@@ -44,9 +41,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows, macos]
-        release: [true, false]
     runs-on: ${{ matrix.os }}-latest
-    name: "[${{ matrix.release == true && 'RELEASE' || 'DEBUG' }}] JVM on ${{ matrix.os }}"
+    name: JVM tests on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -55,9 +51,9 @@ jobs:
           java-version: 21
       - run: chmod +x gradlew
       - uses: gradle/actions/setup-gradle@v4
-      - run: ./gradlew jvmTest "-Pleveldb.release=${{ matrix.release }}"
+      - run: ./gradlew jvmTest
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: tests-results-${{ matrix.os }}-${{ matrix.release == true && 'release' || 'debug' }}
+          name: tests-results-${{ matrix.os }}
           path: build/reports

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -8,9 +8,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows, macos]
-        release: [true, false]
     runs-on: ${{ matrix.os }}-latest
-    name: "[${{ matrix.release == true && 'RELEASE' || 'DEBUG' }}] Kotlin/Native on ${{ matrix.os }}"
+    name: "Kotlin/Native tests on ${{ matrix.os }}"
     steps:
       - uses: actions/checkout@v4
       - uses: gradle/actions/setup-gradle@v4
@@ -22,7 +21,7 @@ jobs:
       - name: Install Rosetta 2
         if: matrix.os == 'macos-latest'
         run: softwareupdate --install-rosetta --agree-to-license
-      - run: ./gradlew :platformSpecificTest --stacktrace "-Pleveldb.release=${{ matrix.release }}"
+      - run: ./gradlew :platformSpecificTest --stacktrace
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -68,9 +68,10 @@ tasks {
     }
     register("runBenchmark") {
         val mode =
-            when {
-                project.properties["leveldb.release"] == "true" -> "Release"
-                else -> "Debug"
+            when (project.properties["leveldb.release"]) {
+                null, "true" -> "Release"
+                "false" -> "Debug"
+                else -> error("Unknown value for leveldb.release")
             }
         val os = OperatingSystem.current()
         val task =


### PR DESCRIPTION
This commit removes the 'release' matrix from workflows to streamline the configurations. The job names are also updated to reflect this change, consolidating their formats. The removed parameter "-Pleveldb.release" from Gradle commands ensures consistent execution without release-specific differentiation.