### PR TITLE
Use release binaries by default

### DIFF
--- a/buildSrc/src/main/kotlin/Utils.kt
+++ b/buildSrc/src/main/kotlin/Utils.kt
@@ -89,7 +89,8 @@ fun Project.registerExtractLevelDbTask(
     destinationDir: Provider<Directory>,
     isRelease: Boolean = project.properties["leveldb.release"]
         ?.let { it as? String }
-        ?.toBooleanStrictOrNull() == true
+        ?.toBooleanStrictOrNull()
+        ?: true
 ) = tasks.registering(Sync::class) {
     dependsOn(downloadLeveDBBinaries)
     strategies.forEach {

--- a/src/commonMain/kotlin/com/github/lamba92/leveldb/LevelDBBatchBuilder.kt
+++ b/src/commonMain/kotlin/com/github/lamba92/leveldb/LevelDBBatchBuilder.kt
@@ -10,7 +10,7 @@ package com.github.lamba92.leveldb
 public inline fun LevelDB.batch(
     sync: Boolean = false,
     builder: LevelDBBatchBuilder.() -> Unit,
-) = batch(buildLevelDBBatch(builder), sync)
+): Unit = batch(buildLevelDBBatch(builder), sync)
 
 /**
  * Constructs and builds a batch operation for LevelDB using a customizable builder.


### PR DESCRIPTION
Not specifying `-Pleveldb.relsase` parameter to the build now will default to `true` instead of `false`.