### PR TITLE
Refactor Gradle tasks for platform-specific publication

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,7 +37,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - run: chmod +x gradlew
-      - run: ./gradlew findSonatypeStagingRepository -x initializeSonatypeStagingRepository publishToSonatype "-Pleveldb.release=true"
+      - run: ./gradlew findSonatypeStagingRepository -x publishPlatformSpecificPublicationsToSonatype
         env:
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}
@@ -57,7 +57,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - run: chmod +x gradlew
-      - run: ./gradlew findSonatypeStagingRepository -x initializeSonatypeStagingRepository closeAndReleaseSonatypeStagingRepository
+      - run: ./gradlew findSonatypeStagingRepository -x closeAndReleaseSonatypeStagingRepository
         env:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,7 +37,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - run: chmod +x gradlew
-      - run: ./gradlew findSonatypeStagingRepository -x publishPlatformSpecificPublicationsToSonatype
+      - run: ./gradlew findSonatypeStagingRepository -x publishToSonatype
         env:
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - run: chmod +x gradlew
-      - run: ./gradlew publishPlatformSpecificPublicationsToSonatype
+      - run: ./gradlew publishToSonatype
         env:
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - run: chmod +x gradlew
-      - run: ./gradlew publishToSonatype "-Pleveldb.release=true"
+      - run: ./gradlew publishPlatformSpecificPublicationsToSonatype
         env:
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -439,42 +439,49 @@ tasks {
         dependsOn(tests)
     }
 
-    // I have not found a better way...
-    val winPublishTasks = listOf("publishMingwX64PublicationTo")
-    val linuxPublishTasks =
-        listOf(
-            "publishAndroidNativeArm32PublicationTo",
-            "publishAndroidNativeArm64PublicationTo",
-            "publishAndroidNativeX64PublicationTo",
-            "publishAndroidNativeX86PublicationTo",
-            "publishAndroidReleasePublicationTo",
-            "publishKotlinMultiplatformPublicationTo",
-            "publishJvmPublicationTo",
-            "publishLinuxArm64PublicationTo",
-            "publishLinuxX64PublicationTo",
-        )
+    val publishWindowsPublicationsToSonatype by registering {
+        onlyIf { currentOs.isWindows }
+        dependsOn("publishMingwX64PublicationToSonatype")
+    }
 
-    val macosPublishTasks =
-        listOf(
-            "publishMacosArm64PublicationTo",
-            "publishMacosX64PublicationTo",
-            "publishIosArm64PublicationTo",
-            "publishIosSimulatorArm64PublicationTo",
-            "publishIosX64PublicationTo",
-            "publishTvosArm64PublicationTo",
-            "publishTvosSimulatorArm64PublicationTo",
-            "publishTvosX64PublicationTo",
-            "publishWatchosArm64PublicationTo",
-            "publishWatchosSimulatorArm64PublicationTo",
-            "publishWatchosX64PublicationTo",
+    val publishLinuxPublicationsToSonatype by registering {
+        onlyIf { currentOs.isLinux }
+        dependsOn(
+            "publishAndroidNativeArm32PublicationToSonatype",
+            "publishAndroidNativeArm64PublicationToSonatype",
+            "publishAndroidNativeX64PublicationToSonatype",
+            "publishAndroidNativeX86PublicationToSonatype",
+            "publishAndroidReleasePublicationToSonatype",
+            "publishKotlinMultiplatformPublicationToSonatype",
+            "publishJvmPublicationToSonatype",
+            "publishLinuxArm64PublicationToSonatype",
+            "publishLinuxX64PublicationToSonatype",
         )
+    }
 
-    all {
-        when {
-            name.startsWithAny(winPublishTasks) -> onlyIf { currentOs.isWindows }
-            name.startsWithAny(linuxPublishTasks) -> onlyIf { currentOs.isLinux }
-            name.startsWithAny(macosPublishTasks) -> onlyIf { currentOs.isMacOsX }
-        }
+    val publishApplePublicationsToSonatype by registering  {
+        onlyIf { currentOs.isMacOsX }
+        dependsOn(
+            "publishMacosArm64PublicationToSonatype",
+            "publishMacosX64PublicationToSonatype",
+            "publishIosArm64PublicationToSonatype",
+            "publishIosSimulatorArm64PublicationToSonatype",
+            "publishIosX64PublicationToSonatype",
+            "publishTvosArm64PublicationToSonatype",
+            "publishTvosSimulatorArm64PublicationToSonatype",
+            "publishTvosX64PublicationToSonatype",
+            "publishWatchosArm64PublicationToSonatype",
+            "publishWatchosSimulatorArm64PublicationToSonatype",
+            "publishWatchosX64PublicationToSonatype",
+        )
+    }
+
+    register("publishPlatformSpecificPublicationsToSonatype") {
+        dependsOn(
+            publishWindowsPublicationsToSonatype,
+            publishLinuxPublicationsToSonatype,
+            publishApplePublicationsToSonatype
+        )
     }
 
     withType<AbstractPublishToMaven> {
@@ -559,5 +566,3 @@ nexusPublishing {
         }
     }
 }
-
-fun String.startsWithAny(strings: List<String>): Boolean = strings.any { startsWith(it) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -459,7 +459,7 @@ tasks {
         )
     }
 
-    val publishApplePublicationsToSonatype by registering  {
+    val publishApplePublicationsToSonatype by registering {
         onlyIf { currentOs.isMacOsX }
         dependsOn(
             "publishMacosArm64PublicationToSonatype",
@@ -480,7 +480,7 @@ tasks {
         dependsOn(
             publishWindowsPublicationsToSonatype,
             publishLinuxPublicationsToSonatype,
-            publishApplePublicationsToSonatype
+            publishApplePublicationsToSonatype,
         )
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -439,49 +439,16 @@ tasks {
         dependsOn(tests)
     }
 
-    val publishWindowsPublicationsToSonatype by registering {
-        onlyIf { currentOs.isWindows }
-        dependsOn("publishMingwX64PublicationToSonatype")
-    }
+    val linuxName = listOf("linux", "android", "jvm", "js", "kotlin", "metadata", "wasm")
+    val windowsName = listOf("mingw", "windows")
+    val appleName = listOf("macos", "ios", "watchos", "tvos")
 
-    val publishLinuxPublicationsToSonatype by registering {
-        onlyIf { currentOs.isLinux }
-        dependsOn(
-            "publishAndroidNativeArm32PublicationToSonatype",
-            "publishAndroidNativeArm64PublicationToSonatype",
-            "publishAndroidNativeX64PublicationToSonatype",
-            "publishAndroidNativeX86PublicationToSonatype",
-            "publishAndroidReleasePublicationToSonatype",
-            "publishKotlinMultiplatformPublicationToSonatype",
-            "publishJvmPublicationToSonatype",
-            "publishLinuxArm64PublicationToSonatype",
-            "publishLinuxX64PublicationToSonatype",
-        )
-    }
-
-    val publishApplePublicationsToSonatype by registering {
-        onlyIf { currentOs.isMacOsX }
-        dependsOn(
-            "publishMacosArm64PublicationToSonatype",
-            "publishMacosX64PublicationToSonatype",
-            "publishIosArm64PublicationToSonatype",
-            "publishIosSimulatorArm64PublicationToSonatype",
-            "publishIosX64PublicationToSonatype",
-            "publishTvosArm64PublicationToSonatype",
-            "publishTvosSimulatorArm64PublicationToSonatype",
-            "publishTvosX64PublicationToSonatype",
-            "publishWatchosArm64PublicationToSonatype",
-            "publishWatchosSimulatorArm64PublicationToSonatype",
-            "publishWatchosX64PublicationToSonatype",
-        )
-    }
-
-    register("publishPlatformSpecificPublicationsToSonatype") {
-        dependsOn(
-            publishWindowsPublicationsToSonatype,
-            publishLinuxPublicationsToSonatype,
-            publishApplePublicationsToSonatype,
-        )
+    withType<AbstractPublishToMaven> {
+        when {
+            name.containsAny(linuxName) -> onlyIf { currentOs.isLinux }
+            name.containsAny(windowsName) -> onlyIf { currentOs.isWindows }
+            name.containsAny(appleName) -> onlyIf { currentOs.isMacOsX }
+        }
     }
 
     withType<AbstractPublishToMaven> {
@@ -566,3 +533,6 @@ nexusPublishing {
         }
     }
 }
+
+fun String.containsAny(strings: List<String>, ignoreCase: Boolean = true): Boolean =
+    strings.any { contains(it, ignoreCase) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -439,15 +439,20 @@ tasks {
         dependsOn(tests)
     }
 
-    val linuxName = listOf("linux", "android", "jvm", "js", "kotlin", "metadata", "wasm")
-    val windowsName = listOf("mingw", "windows")
-    val appleName = listOf("macos", "ios", "watchos", "tvos")
+    // in CI we only want to publish the artifacts for the current OS only
+    // but when developing we want to publish all the possible artifacts to test them
+    if (isCi) {
 
-    withType<AbstractPublishToMaven> {
-        when {
-            name.containsAny(linuxName) -> onlyIf { currentOs.isLinux }
-            name.containsAny(windowsName) -> onlyIf { currentOs.isWindows }
-            name.containsAny(appleName) -> onlyIf { currentOs.isMacOsX }
+        val linuxNames = listOf("linux", "android", "jvm", "js", "kotlin", "metadata", "wasm")
+        val windowsNames = listOf("mingw", "windows")
+        val appleNames = listOf("macos", "ios", "watchos", "tvos")
+
+        withType<AbstractPublishToMaven> {
+            when {
+                name.containsAny(linuxNames) -> onlyIf { currentOs.isLinux }
+                name.containsAny(windowsNames) -> onlyIf { currentOs.isWindows }
+                name.containsAny(appleNames) -> onlyIf { currentOs.isMacOsX }
+            }
         }
     }
 
@@ -536,3 +541,6 @@ nexusPublishing {
 
 fun String.containsAny(strings: List<String>, ignoreCase: Boolean = true): Boolean =
     strings.any { contains(it, ignoreCase) }
+
+val isCi
+    get() = System.getenv("CI") == "true"


### PR DESCRIPTION
This commit refactors the Gradle build script to define platform-specific publication tasks for Windows, Linux, and Apple systems. It introduces a new centralized configuration, improving the organization and clarity of the build process. The change also modifies related workflow files to align with this new structure, ensuring seamless compatibility.