### PR TITLE
Add compileOnly dependency on JNA for jvmCommonMain

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,6 +111,9 @@ kotlin {
 
         val jvmCommonMain by creating {
             dependsOn(commonMain.get())
+            dependencies {
+                compileOnly(libs.jna)
+            }
         }
 
         val jvmCommonTest by creating {


### PR DESCRIPTION
This change allows IntelliJ to correctly resolve symbols in jvmCommonMain source set.